### PR TITLE
Fix code scanning alert no. 2: Disabling certificate validation

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@ process.on('uncaughtException', function (err) {
   console.log('Node NOT Exiting...');
 });
 
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 let express = require('express');
 const helmet = require('helmet');
 let morgan = require('morgan');


### PR DESCRIPTION
Fixes [https://github.com/Dargon789/LndHub/security/code-scanning/2](https://github.com/Dargon789/LndHub/security/code-scanning/2)

To fix the problem, we need to ensure that TLS certificate validation is not disabled. This involves removing or modifying the line that sets `process.env.NODE_TLS_REJECT_UNAUTHORIZED` to '0'. Instead, we should rely on the default behavior of Node.js, which is to validate TLS certificates. If there is a need to disable certificate validation for specific requests during development or testing, it should be done in a controlled manner and not in the main codebase.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Fixed a security vulnerability that disabled TLS certificate validation.